### PR TITLE
Add coveralls support to the repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 os:
   - linux
@@ -43,6 +45,7 @@ before_install:
   - pip install -r requirements-dev.txt
 
 install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y postgresql-9.5-postgis-2.3; fi
   - cd $TRAVIS_BUILD_DIR
   - pip install -e .
 
@@ -56,5 +59,8 @@ before_script:
   - psql -c 'CREATE EXTENSION postgis;' -U postgres -d travis_ci_test
 
 script:
-  - python -m unittest discover
+  - coverage run --source gaia -m unittest discover
   - flake8 --config tests/flake8.cfg gaia tests
+
+after_success:
+  coveralls

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Gaia install:
     export CPLUS_INCLUDE_PATH=/usr/include/gdal
     export C_INCLUDE_PATH=/usr/include/gdal
 
-Gaia [![Build Status](https://api.travis-ci.org/OpenDataAnalytics/gaia.svg?branch=master)](https://travis-ci.org/OpenDataAnalytics/gaia)  [![Documentation Status](https://readthedocs.org/projects/gaia/badge/?version=latest)](https://readthedocs.org/projects/gaia/?badge=latest) [![Join the chat at https://gitter.im/OpenGeoscience/gaia](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OpenGeoscience/gaia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+Gaia [![Build Status](https://api.travis-ci.org/OpenDataAnalytics/gaia.svg?branch=master)](https://travis-ci.org/OpenDataAnalytics/gaia)  [![Documentation Status](https://readthedocs.org/projects/gaia/badge/?version=latest)](https://readthedocs.org/projects/gaia/?badge=latest) [![Join the chat at https://gitter.im/OpenGeoscience/gaia](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/OpenGeoscience/gaia?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Coverage Status](https://coveralls.io/repos/github/dorukozturk/gaia/badge.svg)](https://coveralls.io/github/dorukozturk/gaia)
 
 
 #### License

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ flake8-blind-except==0.1.0
 flake8-docstrings==0.2.1.post1
 rauth==0.7.2
 mock==0.7.2
+coveralls==1.1


### PR DESCRIPTION
@aashish24 Fixes #94 and #67 

Currently the badge url is pointing to the fork that I created. That needs to be changed. I did not have access credentials to add the main gaia repository to coveralls. 