### PR TITLE
Test transform and projection for empty

### DIFF
--- a/gaia/inputs.py
+++ b/gaia/inputs.py
@@ -131,6 +131,8 @@ class GaiaIO(object):
                     return self.epsg
         elif self.data.__class__.__name__ == 'Dataset':
             projection = self.data.GetProjection()
+            if projection == '':
+                projection = self.data.GetGCPProjection()
             data_crs = osr.SpatialReference(wkt=projection)
             try:
                 self.epsg = int(data_crs.GetAttrValue('AUTHORITY', 1))


### PR DESCRIPTION
When the projection is empty or the transform is identity we can call a GCP related function since the data is stored differently