### PR TITLE
Include parsed requirement.txt in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,8 +69,8 @@ setup(
             'conf/*',
         ]
     },
-    #require_python='>=2.6',
+    # require_python='>=2.6',
     url='https://github.com/OpenDataAnalytics/gaia',
-    #install_requires=requires,
-    #extras_require=extras
+    install_requires=requires,
+    # extras_require=extras
 )


### PR DESCRIPTION
I'm not sure why this was disabled, but it is useful to reenable installing requirements from setup.py so modules that depend on gaia don't have to determine install these manually.