### PR TITLE
Fix pyOpenSSL requirement.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ gdal>=2.1.0
 psycopg2>=2.6.1
 geoalchemy2>=0.2.6
 rasterio>=0.36.0
-pyOpenSSL>=0.17
+pyOpenSSL>=17.0.0


### PR DESCRIPTION
At some point pyOpenSSL went from versions like 0.x.y to x.y.z, so this should be >=17.0.0 not >=0.17.0.