### PR TITLE
Debug/generalize geojson display

### DIFF
--- a/docs/examples/lidar_vectors.ipynb
+++ b/docs/examples/lidar_vectors.ipynb
@@ -1,0 +1,176 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Icon_', 'Ground_Survey_Shapes', 'Contours', 'Water_Shape', 'Indices']"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "#\n",
+    "# IMPORTANT! YOU MUST SET data_dir TO YOUR COPY OF THE LiDAR DATASET!\n",
+    "#\n",
+    "\n",
+    "data_dir = '/home/john/projects/data2models/data/EastRiverWashingtonGulch/LiDAR'\n",
+    "vectors_dir = os.path.join(data_dir, 'Vectors')\n",
+    "os.listdir(vectors_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0. .../Ground_Survey_Shapes/East_River_Washington_Gulch_Ground_Control_Monuments.shp\n",
+      "1. .../Ground_Survey_Shapes/East_River_Washington_Gulch_Ground_Control_Points.shp\n",
+      "2. .../Ground_Survey_Shapes/East_River_Washington_Gulch_Ground_Check_Points.shp\n",
+      "3. .../Contours/WAG_371.shp\n",
+      "4. .../Contours/WAG_025.shp\n",
+      "5. .../Contours/WAG_255.shp\n",
+      "6. .../Contours/WAG_004.shp\n",
+      "7. .../Contours/WAG_014.shp\n",
+      "8. .../Contours/WAG_003.shp\n",
+      "9. .../Contours/WAG_015.shp\n",
+      "10. .../Contours/WAG_352.shp\n",
+      "11. .../Contours/WAG_353.shp\n",
+      "12. .../Contours/WAG_003 (1).shp\n",
+      "13. .../Water_Shape/East_River_Washington_Gulch_Water_Breaklines.shp\n",
+      "14. .../Indices/East_River_Washington_Gulch_Boundary.shp\n",
+      "15. .../Indices/East_River_Washington_Gulch_Tile_Index.shp\n"
+     ]
+    }
+   ],
+   "source": [
+    "import glob\n",
+    "\n",
+    "pattern = '{}/**/*.shp'.format(vectors_dir)\n",
+    "# for filename in glob.iglob(pattern, recursive=True):\n",
+    "#     print(filename)\n",
+    "shp_files = list(glob.iglob(pattern, recursive=True))\n",
+    "n = len(vectors_dir) + 1\n",
+    "for i,path in enumerate(shp_files):\n",
+    "    print('{}. .../{}'.format(i, path[n:]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gaia\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "827ca39f0b854276b356aac5b3af9078",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "scene(center={'y': 0.0, 'x': 0.0}, layout=Layout(align_self='stretch', height='400px'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "monuments = gaia.create(shp_files[0])\n",
+    "wag371 = gaia.create(shp_files[3])\n",
+    "breaklines = gaia.create(shp_files[13])\n",
+    "boundary = gaia.create(shp_files[14])\n",
+    "tile_index = gaia.create(shp_files[15])\n",
+    "\n",
+    "scene = gaia.show([monuments, wag371, breaklines, boundary, tile_index])\n",
+    "display(scene)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add zoom slider\n",
+    "import ipywidgets as widgets\n",
+    "z = widgets.FloatSlider(min=1, max=18, value=scene.zoom, layout=dict(width='95%'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6922f201160406cbf8c244102c68dcf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=11.058348, layout=Layout(width='95%'), max=18.0, min=1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "newlink = widgets.jslink((z, 'value'), (scene, 'zoom'))\n",
+    "display(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gaia/io/geojson_reader.py
+++ b/gaia/io/geojson_reader.py
@@ -38,8 +38,8 @@ class GaiaGeoJSONReader(GaiaReader):
         if not isinstance(url, string_types):
             return False
 
-        extension = get_uri_extension(url)
-        if extension == 'geojson':
+        extension = '.{}'.format(get_uri_extension(url))
+        if extension in formats.VECTOR:
             return True
         return False
 


### PR DESCRIPTION
This branch has a number of changes based on debug/testing with LiDAR vector data provided by Berkeley several months ago.

* Add support for all vector formats (was just geojson)
* Convert data to epsg4236 coordinates if needed
* Replace z coordinate with 1.0
* Also fix GaiaDataObject.reproject to update epsg and metadata

![gaialidar](https://user-images.githubusercontent.com/5559383/48871435-b9aec380-edb2-11e8-9ac2-e322644e9809.png)
