### PR TITLE
NERSC job submission

### DIFF
--- a/docs/examples/ess_dive.ipynb
+++ b/docs/examples/ess_dive.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geolib\n",
+    "\n",
+    "girder_url = 'http://anka:8080'\n",
+    "api_key = '3x8bBbwik9TLlS9lJU8Z8qNeNLfQQsm9QPU7FrkS'\n",
+    "girder = geolib.connect(girder_url=girder_url, apikey=api_key)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "364c78d1187949d3887f5ac59ff8751b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "scene(center={'y': 0.0, 'x': 0.0}, layout=Layout(align_self='stretch', height='400px'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dataset_path = 'Public/PH_community_distribution_map.tif'\n",
+    "#dataset_path = 'Public/PH_plant_height_map.tif'\n",
+    "data_url = girder.lookup_url(dataset_path)\n",
+    "dataset = geolib.create(data_url)\n",
+    "dataset._epsg = '4326'\n",
+    "dataset._setdatatype(geolib.types.RASTER)\n",
+    "dataset.opacity = 0.8\n",
+    "\n",
+    "# Fix metadata\n",
+    "metadata = dataset.get_metadata()\n",
+    "dataset._metadata['bounds']['coordinates'] = [[\n",
+    "    [-106.95242631255823, 38.92484206381101],\n",
+    "    [-106.95224175189571, 38.91810990322611],\n",
+    "    [-106.94362420673949, 38.91825374356009],\n",
+    "    [-106.94380795397146, 38.92498593850482]\n",
+    "]]\n",
+    "\n",
+    "scene1 = geolib.show(dataset)\n",
+    "display(scene1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3b856056dee24bf68b6db715382d30a5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=15.5, layout=Layout(width='95%'), max=18.0, min=1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "z1 = widgets.FloatSlider(min=1, max=18, value=scene1.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((z1, 'value'), (scene1, 'zoom'))\n",
+    "display(z1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb006764b9324692beae9be3ef1db2e0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "scene(center={'y': 0.0, 'x': 0.0}, layout=Layout(align_self='stretch', height='400px'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import geojson\n",
+    "\n",
+    "# Create vector object for dataset bounds\n",
+    "meta = dataset.get_metadata()\n",
+    "bounds = meta.get('bounds',{})\n",
+    "# assert bounds, 'Dataset bounds missing'\n",
+    "\n",
+    "bounds_feature = geojson.Feature(geometry=bounds, properties={'fillColor': 'black', 'fillOpacity': 0.1})\n",
+    "bounds_object = geolib.create(bounds_feature)\n",
+    "\n",
+    "# Compute simple crop region inside the dataset\n",
+    "coords = bounds.get('coordinates')[0]\n",
+    "xvals, yvals = zip(*coords)\n",
+    "xmin = min(xvals); ymin = min(yvals)\n",
+    "xmax = max(xvals); ymax = max(yvals)\n",
+    "\n",
+    "# Compute center coordinates\n",
+    "x = (xmin + xmax) / 2.0\n",
+    "y = (ymin + ymax) / 2.0\n",
+    "\n",
+    "# Use percentage of height & width\n",
+    "dx = 0.12 * (xmax - xmin)\n",
+    "dy = 0.18 * (ymax - ymin)\n",
+    "poly = [[x,y], [x+dx,y+dy], [x-dx,y+dy], [x-dx,y-dy], [x+dx,y-dy]]\n",
+    "\n",
+    "crop_geom = geojson.Polygon([poly])\n",
+    "crop_feature = geojson.Feature(geometry=crop_geom, properties={'fillColor': 'magenta', 'fillOpacity': 0.6})\n",
+    "crop_object = geolib.create(crop_feature)\n",
+    "scene2 = geolib.show([crop_object, bounds_object])\n",
+    "display(scene2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d66e2390dd6b4a8db4f5520ba7c2adc4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=15.5, layout=Layout(width='95%'), max=18.0, min=1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "z2 = widgets.FloatSlider(min=1, max=18, value=scene2.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((z2, 'value'), (scene2, 'zoom'))\n",
+    "display(z2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/job_submit.ipynb
+++ b/docs/examples/job_submit.ipynb
@@ -7,7 +7,8 @@
    "outputs": [],
    "source": [
     "# Set NEWT session id\n",
-    "newt_sessionid = '04d401b204b77487f4fc94cf1b92bacf'\n"
+    "newt_sessionid = '57311ce617ff392d7b6cb6104b0a18dc'\n",
+    "nersc_repository = None"
    ]
   },
   {
@@ -45,7 +46,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1e9ca1f8b01e4c8791e32dfe7219e0be",
+       "model_id": "0a92dd2598fd4897bfe8b0d3c5c43211",
        "version_major": 2,
        "version_minor": 0
       },
@@ -93,10 +94,9 @@
     "geometry = geojson.Polygon(poly)\n",
     "crop_feature = geojson.Feature(geometry=geometry, properties={'fillColor': 'magenta', 'fillOpacity': 0.5})\n",
     "crop_object = geolib.create(crop_feature)\n",
-    "# print(crop_object, crop_object._getdatatype())\n",
     "\n",
-    "scene = geolib.show([crop_object, essdive_object])\n",
-    "display(scene)\n"
+    "scene1 = geolib.show([crop_object, essdive_object])\n",
+    "display(scene1)\n"
    ]
   },
   {
@@ -107,7 +107,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "5f78fd6adfe74a7ea2eecd4b17976271",
+       "model_id": "c11bbef3782f4beea50c5fabe39b5905",
        "version_major": 2,
        "version_minor": 0
       },
@@ -121,8 +121,8 @@
    ],
    "source": [
     "import ipywidgets as widgets\n",
-    "z = widgets.FloatSlider(min=1, max=16, value=scene.zoom, layout=dict(width='95%'))\n",
-    "newlink = widgets.jslink((z, 'value'), (scene, 'zoom'))\n",
+    "z = widgets.FloatSlider(min=1, max=16, value=scene1.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((z, 'value'), (scene1, 'zoom'))\n",
     "display(z)"
    ]
   },
@@ -132,20 +132,46 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "'no job id yet'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter NERSC repository (account):  ·····\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(CumulusClient) ginterface <gaia.io.girder_interface.GirderInterface object at 0x7f2b4ffac828>\n",
+      "(CumulusClient) gclient <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
+      "set girder_client <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
+      "user {'groups': [], 'emailVerified': True, 'status': 'enabled', 'created': '2018-01-18T18:39:26.139000+00:00', 'lastName': 'Tourtellott', '_id': '5a60e9de0640fd01195132e4', 'groupInvites': [], 'email': 'john.tourtellott@kitware.com', '_accessLevel': 2, 'login': 'johnt', 'size': 1125529012, 'public': True, '_modelType': 'user', 'admin': True, 'firstName': 'John'}\n",
+      "private_folder_id 5a60e9de0640fd01195132e6\n",
+      "checking girder_client <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
+      "Creating cluster on cori\n",
+      "status created\n",
+      "status running\n",
+      "Creating SLURM script geolib\n",
+      "script_id 5c8ad6ee0640fd012102b898\n",
+      "Creating job geolib\n",
+      "Created job folder 0ecff36a39f1463fb1dc7ae092e56780\n",
+      "Created job_id 5c8ad6ef0640fd012102b89c\n",
+      "Uploading geometry file\n",
+      "Submitting job\n",
+      "submit_job body: {'constraint': 'haswell', 'machine': 'cori', 'numberOfNodes': 1, 'account': 'm2690', 'maxWallTime': {'seconds': 0, 'hours': 0, 'minutes': 5}, 'jobOutputDir': '/global/cscratch1/sd/johnt/190314/geolib', 'queue': 'debug'}\n",
+      "Submitted job 5c8ad6ef0640fd012102b89c\n"
+     ]
     }
    ],
    "source": [
     "# To run on Girder:\n",
     "# cropped_object = gaia.crop(essdiv_object, crop_object)\n",
-    "cori_job = geolib.submit_crop(essdive_object, crop_object)\n",
+    "\n",
+    "# To run on NERSC\n",
+    "import getpass\n",
+    "while not nersc_repository:\n",
+    "    nersc_repository = getpass.getpass('Enter NERSC repository (account): ')\n",
+    "cori_job = geolib.submit_crop(essdive_object, crop_object, nersc_repository)\n",
     "cori_job"
    ]
   },

--- a/docs/examples/job_submit.ipynb
+++ b/docs/examples/job_submit.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Configure GeoLib to use Girder & NERSC resources"
+    "# 1. Configure GeoLib to use Girder & NERSC resources"
    ]
   },
   {
@@ -13,8 +13,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set NEWT session id\n",
-    "newt_sessionid = '57311ce617ff392d7b6cb6104b0a18dc'\n",
+    "# Get NEWT session id\n",
+    "import os\n",
+    "newt_sessionid = open(os.path.expanduser('~/temp/newt_sessionid.txt')).read().strip()\n",
     "nersc_repository = None"
    ]
   },
@@ -22,45 +23,74 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'output': '/global/cscratch1/sd/johnt', 'error': '', 'status': 'OK'}\n"
+     ]
+    }
+   ],
    "source": [
-    "# Load Gaia and connect to girder using NEWT session id\n",
+    "# Load GeoLib and connect to girder using NEWT session id\n",
     "import geolib\n",
-    "girder = geolib.connect(girder_url='http://turtleland4:8080', newt_sessionid=newt_sessionid)"
+    "girder_url = 'http://turtleland4:8085'\n",
+    "girder = geolib.connect(girder_url=girder_url, newt_sessionid=newt_sessionid)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Select dataset from ESS-DIVE"
+    "# 2. Select dataset from ESS-DIVE"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[['2.1 MB', 'PH_community_distribution_map.tif'],\n",
+       " ['8.5 MB', 'PH_plant_height_map.tif'],\n",
+       " ['8.2 KB',\n",
+       "  'Remote Sensing and Geophysical Characterization of a Floodplain-Hillslope System in the East River Watershed, Colorado.xml']]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Todo select item from ESS-DIVE\n",
-    "\n",
-    "# As a surrogate, use file that was uploaded manually\n",
-    "resource_type = 'item'\n",
-    "resource_id = '5c88076206a1b5013e1c6d77'    # /user/admin/Public/local/SFBay_grayscale.tif\n",
-    "girder_url = 'girder://{}/{}'.format(resource_type, resource_id)\n",
-    "\n",
-    "essdive_object = geolib.create(girder_url)"
+    "girder.ls('/user/admin/Public')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select item from ESS-DIVE\n",
+    "\n",
+    "girder_path = '/user/admin/Public/PH_community_distribution_map.tif'\n",
+    "girder_url = girder.lookup_url(girder_path)\n",
+    "essdive_object = geolib.create(girder_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "780be96284e44d7abab76c12f750d8c6",
+       "model_id": "f51827510e1340ddbb9720306317585d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -73,20 +103,52 @@
     }
    ],
    "source": [
-    "# Get bounds\n",
-    "# metadata = essdive_object.get_metadata()\n",
-    "metadata = {\n",
-    " 'bounds': {'coordinates': [[[-122.71879201711467, 37.45219874192699],\n",
-    "    [-122.71879201711467, 38.052231141926995],\n",
-    "    [-122.11875961711466, 38.052231141926995],\n",
-    "    [-122.11875961711466, 37.45219874192699],\n",
-    "    [-122.71879201711467, 37.45219874192699]]],\n",
-    "  'type': 'Polygon'},\n",
-    " 'height': 4323,\n",
-    " 'width': 4323}\n",
+    "# Fix metadata\n",
+    "essdive_object._epsg = 4326\n",
+    "essdive_object._setdatatype(geolib.types.RASTER)\n",
+    "if girder_path.split('/')[-1] in ['PH_community_distribution_map.tif', 'PH_plant_height_map.tif']:\n",
+    "    metadata = essdive_object.get_metadata()\n",
+    "    essdive_object._metadata['bounds']['coordinates'] = [[\n",
+    "        [-106.95242631255823, 38.92484206381101],\n",
+    "        [-106.95224175189571, 38.91810990322611],\n",
+    "        [-106.94362420673949, 38.91825374356009],\n",
+    "        [-106.94380795397146, 38.92498593850482]\n",
+    "    ]]\n",
     "\n",
+    "essdive_object.opacity = 0.5\n",
+    "geolib.show(essdive_object)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 3. Define Crop Geometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d9f1d45b5f94471bbfcf610cb80e35cd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "scene(center={'x': 0.0, 'y': 0.0}, layout=Layout(align_self='stretch', height='400px'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
     "# Create polygon to display bounds\n",
-    "bounds = metadata.get('bounds')\n",
+    "bounds = essdive_object.get_metadata().get('bounds')\n",
     "coordinates = bounds.get('coordinates')\n",
     "import geojson\n",
     "bounds_geometry = geojson.Polygon(coordinates)\n",
@@ -112,23 +174,23 @@
     "crop_object = geolib.create(crop_feature)\n",
     "\n",
     "scene1 = geolib.show([crop_object, bounds_object])\n",
-    "display(scene1)\n"
+    "display(scene1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b3656931854a471db70c1dffad6b900d",
+       "model_id": "364b481804fc4a4d93036c95c5a13eea",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "FloatSlider(value=9.328175, layout=Layout(width='95%'), max=16.0, min=1.0)"
+       "FloatSlider(value=15.5, layout=Layout(width='95%'), max=16.0, min=1.0)"
       ]
      },
      "metadata": {},
@@ -137,63 +199,28 @@
    ],
    "source": [
     "import ipywidgets as widgets\n",
-    "z = widgets.FloatSlider(min=1, max=16, value=scene1.zoom, layout=dict(width='95%'))\n",
-    "newlink = widgets.jslink((z, 'value'), (scene1, 'zoom'))\n",
-    "display(z)"
+    "slider1 = widgets.FloatSlider(min=1, max=16, value=scene1.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((slider1, 'value'), (scene1, 'zoom'))\n",
+    "display(slider1)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Submit preprocesssing job on NERSC (Cori)"
+    "# 4. Submit preprocesssing job on NERSC (Cori)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Enter NERSC repository (account):  ·····\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "user {'groups': [], 'status': 'enabled', 'size': 1125534158, 'emailVerified': True, 'login': 'johnt', 'lastName': 'Tourtellott', '_modelType': 'user', 'public': True, 'admin': True, 'groupInvites': [], 'email': 'john.tourtellott@kitware.com', '_id': '5a60e9de0640fd01195132e4', '_accessLevel': 2, 'created': '2018-01-18T18:39:26.139000+00:00', 'firstName': 'John'}\n",
-      "Creating cluster on cori\n",
-      "Creating SLURM script geolib\n",
-      "script_id 5c8bec8b0640fd012102b8cd\n",
-      "Creating job geolib\n",
-      "Created job folder fac10aaefabc4903b07ce907dd79879c\n",
-      "Created job_id 5c8bec8b0640fd012102b8d1\n",
-      "Uploading geometry file\n",
-      "Submitting job\n",
-      "submit_job body: {'maxWallTime': {'minutes': 5, 'seconds': 0, 'hours': 0}, 'constraint': 'knl', 'numberOfNodes': 1, 'machine': 'cori', 'account': 'm2690', 'jobOutputDir': '/global/cscratch1/sd/johnt/geolib/190315/geolib', 'queue': 'debug'}\n",
-      "Submitted job 5c8bec8b0640fd012102b8d1\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'5c8bec8b0640fd012102b8d1'"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# To run on Girder:\n",
-    "# cropped_object = gaia.crop(essdive_object, crop_object)\n",
-    "\n",
-    "# To run on NERSC\n",
+    "# To run on local machine or Girder:\n",
+    "# output_object = geolib.crop(essdive_object, crop_object)\n",
+    "nersc_repository = None\n",
+    "# To run on NERSC:\n",
     "import getpass\n",
     "while not nersc_repository:\n",
     "    nersc_repository = getpass.getpass('Enter NERSC repository (account): ')\n",
@@ -205,43 +232,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Use job id to create GeoLib object"
+    "# 5. Use job id to create GeoLib object"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Enter girder job id:  5c8bec8b0640fd012102b8d1\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "job_id = input('Enter girder job id: ')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "output_object <gaia.girder_data.GirderDataObject object at 0x7f0f1a3ac8d0>\n"
-     ]
-    }
-   ],
-   "source": [
-    "geolib_url = girder.lookup_url(job_id=job_id)\n",
-    "output_object = geolib.create(geolib_url)\n",
-    "print('output_object', output_object)\n"
+    "job_id = cori_job"
    ]
   },
   {
@@ -250,9 +250,53 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Todo - display cropped dataset - need girder instance with geometa and large-image\n",
-    "# geolib.show(output_object)\n"
+    "job_id = '5c93c50ded1b6319b488e3dc'  # (PH_community_distribution_map.tif)\n",
+    "\n",
+    "girder_url2 = girder.lookup_url(job_id=job_id)\n",
+    "output_object = geolib.create(girder_url2, bounds=[x-dx,y-dy,x+dx,y+dy])\n",
+    "# print('output_object', output_object)\n",
+    "\n",
+    "# Display cropped dataset (must again set metadata)\n",
+    "output_object._epsg = 4326\n",
+    "output_object._setdatatype(geolib.types.RASTER)\n",
+    "output_object.opacity = 0.8\n",
+    "scene2 = geolib.show(output_object)\n",
+    "display(scene2)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf66ca7801054e809530213122567473",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=15.5, layout=Layout(width='95%'), max=20.0, min=1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "slider2 = widgets.FloatSlider(min=1, max=20, value=scene2.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((slider2, 'value'), (scene2, 'zoom'))\n",
+    "display(slider2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/job_submit.ipynb
+++ b/docs/examples/job_submit.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set NEWT session id\n",
+    "newt_sessionid = '04d401b204b77487f4fc94cf1b92bacf'\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load Gaia and connect to girder using NEWT session id\n",
+    "import geolib\n",
+    "girder = geolib.connect(girder_url='http://turtleland4:8080', newt_sessionid=newt_sessionid)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Todo select item from ESS-DIVE\n",
+    "\n",
+    "# As a surrogate, use file that was uploaded manually\n",
+    "resource_type = 'item'\n",
+    "resource_id = '5c88076206a1b5013e1c6d77'    # /user/admin/Public/local/SFBay_grayscale.tif\n",
+    "girder_url = 'girder://{}/{}'.format(resource_type, resource_id)\n",
+    "\n",
+    "essdive_object = geolib.create(girder_url)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1e9ca1f8b01e4c8791e32dfe7219e0be",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "scene(center={'x': 0.0, 'y': 0.0}, layout=Layout(align_self='stretch', height='400px'))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Get bounds\n",
+    "# metadata = essdive_object.get_metadata()\n",
+    "metadata = {\n",
+    " 'bounds': {'coordinates': [[[-122.71879201711467, 37.45219874192699],\n",
+    "    [-122.71879201711467, 38.052231141926995],\n",
+    "    [-122.11875961711466, 38.052231141926995],\n",
+    "    [-122.11875961711466, 37.45219874192699],\n",
+    "    [-122.71879201711467, 37.45219874192699]]],\n",
+    "  'type': 'Polygon'},\n",
+    " 'height': 4323,\n",
+    " 'width': 4323}\n",
+    "\n",
+    "# Create polygon to display bounds\n",
+    "bounds = metadata.get('bounds')\n",
+    "coordinates = bounds.get('coordinates')\n",
+    "import geojson\n",
+    "geometry = geojson.Polygon(coordinates)\n",
+    "essdive_feature = geojson.Feature(geometry=geometry, properties={'fillColor': 'black', 'fillOpacity': 0.2})\n",
+    "essdive_object = geolib.create(essdive_feature)\n",
+    "\n",
+    "# Generate small crop geometry\n",
+    "bounds  = coordinates\n",
+    "bounds = bounds[0]\n",
+    "x = (bounds[0][0] + bounds[2][0]) / 2.0\n",
+    "y = (bounds[0][1] + bounds[2][1]) / 2.0\n",
+    "\n",
+    "# Use small percentage of height & width\n",
+    "dx = 0.12 * (bounds[2][0] - bounds[0][0])\n",
+    "dy = 0.16 * (bounds[2][1] - bounds[0][1])\n",
+    "poly = [[\n",
+    "    [x,y], [x+dx,y+dy], [x-dx,y+dy], [x-dx,y-dy], [x+dx,y-dy]\n",
+    "]]\n",
+    "geometry = geojson.Polygon(poly)\n",
+    "crop_feature = geojson.Feature(geometry=geometry, properties={'fillColor': 'magenta', 'fillOpacity': 0.5})\n",
+    "crop_object = geolib.create(crop_feature)\n",
+    "# print(crop_object, crop_object._getdatatype())\n",
+    "\n",
+    "scene = geolib.show([crop_object, essdive_object])\n",
+    "display(scene)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5f78fd6adfe74a7ea2eecd4b17976271",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "FloatSlider(value=9.328175, layout=Layout(width='95%'), max=16.0, min=1.0)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "z = widgets.FloatSlider(min=1, max=16, value=scene.zoom, layout=dict(width='95%'))\n",
+    "newlink = widgets.jslink((z, 'value'), (scene, 'zoom'))\n",
+    "display(z)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'no job id yet'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# To run on Girder:\n",
+    "# cropped_object = gaia.crop(essdiv_object, crop_object)\n",
+    "cori_job = geolib.submit_crop(essdive_object, crop_object)\n",
+    "cori_job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/job_submit.ipynb
+++ b/docs/examples/job_submit.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Configure GeoLib to use Girder & NERSC resources"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -19,7 +26,14 @@
    "source": [
     "# Load Gaia and connect to girder using NEWT session id\n",
     "import geolib\n",
-    "girder = geolib.connect(girder_url='http://turtleland4:8080', newt_sessionid=newt_sessionid)\n"
+    "girder = geolib.connect(girder_url='http://turtleland4:8080', newt_sessionid=newt_sessionid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Select dataset from ESS-DIVE"
    ]
   },
   {
@@ -35,7 +49,7 @@
     "resource_id = '5c88076206a1b5013e1c6d77'    # /user/admin/Public/local/SFBay_grayscale.tif\n",
     "girder_url = 'girder://{}/{}'.format(resource_type, resource_id)\n",
     "\n",
-    "essdive_object = geolib.create(girder_url)\n"
+    "essdive_object = geolib.create(girder_url)"
    ]
   },
   {
@@ -46,7 +60,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0a92dd2598fd4897bfe8b0d3c5c43211",
+       "model_id": "780be96284e44d7abab76c12f750d8c6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -75,27 +89,29 @@
     "bounds = metadata.get('bounds')\n",
     "coordinates = bounds.get('coordinates')\n",
     "import geojson\n",
-    "geometry = geojson.Polygon(coordinates)\n",
-    "essdive_feature = geojson.Feature(geometry=geometry, properties={'fillColor': 'black', 'fillOpacity': 0.2})\n",
-    "essdive_object = geolib.create(essdive_feature)\n",
+    "bounds_geometry = geojson.Polygon(coordinates)\n",
+    "bounds_feature = geojson.Feature(geometry=bounds_geometry, properties={'fillColor': 'black', 'fillOpacity': 0.2})\n",
+    "bounds_object = geolib.create(bounds_feature)\n",
     "\n",
     "# Generate small crop geometry\n",
-    "bounds  = coordinates\n",
-    "bounds = bounds[0]\n",
-    "x = (bounds[0][0] + bounds[2][0]) / 2.0\n",
-    "y = (bounds[0][1] + bounds[2][1]) / 2.0\n",
+    "coords = coordinates[0]\n",
+    "xvals, yvals = zip(*coords)\n",
+    "xmin = min(xvals); ymin = min(yvals)\n",
+    "xmax = max(xvals); ymax = max(yvals)\n",
+    "x = (xmin + xmax) / 2.0\n",
+    "y = (ymin + ymax) / 2.0\n",
     "\n",
     "# Use small percentage of height & width\n",
-    "dx = 0.12 * (bounds[2][0] - bounds[0][0])\n",
-    "dy = 0.16 * (bounds[2][1] - bounds[0][1])\n",
+    "dx = 0.12 * (xmax - xmin)\n",
+    "dy = 0.16 * (ymax - ymin)\n",
     "poly = [[\n",
     "    [x,y], [x+dx,y+dy], [x-dx,y+dy], [x-dx,y-dy], [x+dx,y-dy]\n",
     "]]\n",
-    "geometry = geojson.Polygon(poly)\n",
-    "crop_feature = geojson.Feature(geometry=geometry, properties={'fillColor': 'magenta', 'fillOpacity': 0.5})\n",
+    "crop_geometry = geojson.Polygon(poly)\n",
+    "crop_feature = geojson.Feature(geometry=crop_geometry, properties={'fillColor': 'magenta', 'fillOpacity': 0.5})\n",
     "crop_object = geolib.create(crop_feature)\n",
     "\n",
-    "scene1 = geolib.show([crop_object, essdive_object])\n",
+    "scene1 = geolib.show([crop_object, bounds_object])\n",
     "display(scene1)\n"
    ]
   },
@@ -107,7 +123,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c11bbef3782f4beea50c5fabe39b5905",
+       "model_id": "b3656931854a471db70c1dffad6b900d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -127,6 +143,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Submit preprocesssing job on NERSC (Cori)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
@@ -142,30 +165,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "(CumulusClient) ginterface <gaia.io.girder_interface.GirderInterface object at 0x7f2b4ffac828>\n",
-      "(CumulusClient) gclient <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
-      "set girder_client <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
-      "user {'groups': [], 'emailVerified': True, 'status': 'enabled', 'created': '2018-01-18T18:39:26.139000+00:00', 'lastName': 'Tourtellott', '_id': '5a60e9de0640fd01195132e4', 'groupInvites': [], 'email': 'john.tourtellott@kitware.com', '_accessLevel': 2, 'login': 'johnt', 'size': 1125529012, 'public': True, '_modelType': 'user', 'admin': True, 'firstName': 'John'}\n",
-      "private_folder_id 5a60e9de0640fd01195132e6\n",
-      "checking girder_client <girder_client.GirderClient object at 0x7f2b4ffac7b8>\n",
+      "user {'groups': [], 'status': 'enabled', 'size': 1125534158, 'emailVerified': True, 'login': 'johnt', 'lastName': 'Tourtellott', '_modelType': 'user', 'public': True, 'admin': True, 'groupInvites': [], 'email': 'john.tourtellott@kitware.com', '_id': '5a60e9de0640fd01195132e4', '_accessLevel': 2, 'created': '2018-01-18T18:39:26.139000+00:00', 'firstName': 'John'}\n",
       "Creating cluster on cori\n",
-      "status created\n",
-      "status running\n",
       "Creating SLURM script geolib\n",
-      "script_id 5c8ad6ee0640fd012102b898\n",
+      "script_id 5c8bec8b0640fd012102b8cd\n",
       "Creating job geolib\n",
-      "Created job folder 0ecff36a39f1463fb1dc7ae092e56780\n",
-      "Created job_id 5c8ad6ef0640fd012102b89c\n",
+      "Created job folder fac10aaefabc4903b07ce907dd79879c\n",
+      "Created job_id 5c8bec8b0640fd012102b8d1\n",
       "Uploading geometry file\n",
       "Submitting job\n",
-      "submit_job body: {'constraint': 'haswell', 'machine': 'cori', 'numberOfNodes': 1, 'account': 'm2690', 'maxWallTime': {'seconds': 0, 'hours': 0, 'minutes': 5}, 'jobOutputDir': '/global/cscratch1/sd/johnt/190314/geolib', 'queue': 'debug'}\n",
-      "Submitted job 5c8ad6ef0640fd012102b89c\n"
+      "submit_job body: {'maxWallTime': {'minutes': 5, 'seconds': 0, 'hours': 0}, 'constraint': 'knl', 'numberOfNodes': 1, 'machine': 'cori', 'account': 'm2690', 'jobOutputDir': '/global/cscratch1/sd/johnt/geolib/190315/geolib', 'queue': 'debug'}\n",
+      "Submitted job 5c8bec8b0640fd012102b8d1\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'5c8bec8b0640fd012102b8d1'"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
     "# To run on Girder:\n",
-    "# cropped_object = gaia.crop(essdiv_object, crop_object)\n",
+    "# cropped_object = gaia.crop(essdive_object, crop_object)\n",
     "\n",
     "# To run on NERSC\n",
     "import getpass\n",
@@ -176,11 +202,57 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use job id to create GeoLib object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter girder job id:  5c8bec8b0640fd012102b8d1\n"
+     ]
+    }
+   ],
+   "source": [
+    "job_id = input('Enter girder job id: ')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "output_object <gaia.girder_data.GirderDataObject object at 0x7f0f1a3ac8d0>\n"
+     ]
+    }
+   ],
+   "source": [
+    "geolib_url = girder.lookup_url(job_id=job_id)\n",
+    "output_object = geolib.create(geolib_url)\n",
+    "print('output_object', output_object)\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Todo - display cropped dataset - need girder instance with geometa and large-image\n",
+    "# geolib.show(output_object)\n"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/nersc_login.ipynb
+++ b/docs/examples/nersc_login.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Username:  johnt\n",
+      "Password:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Log into nersc account and get newt session id\n",
+    "\"\"\"\n",
+    "\n",
+    "import getpass\n",
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "import requests\n",
+    "\n",
+    "nersc_url = 'https://newt.nersc.gov/newt'\n",
+    "\n",
+    "\n",
+    "user = input('Username: ')\n",
+    "password = getpass.getpass(prompt='Password: ')\n",
+    "otp = input('Enter one time password (for MFA) ')\n",
+    "# print('ready')\n",
+    "\n",
+    "credentials = {\n",
+    "    'username': user,\n",
+    "    'password': password + str(otp)\n",
+    "}\n",
+    "\n",
+    "url = '{}/login/'.format(nersc_url)\n",
+    "r = requests.post(url, data=credentials)\n",
+    "r.raise_for_status()\n",
+    "\n",
+    "js = r.json()\n",
+    "if not js.get('auth'):\n",
+    "    raise RuntimeError('NOT authenticated: ', r.text)\n",
+    "\n",
+    "# (else)\n",
+    "session_id = js.get('newt_sessionid')\n",
+    "print('newt_sessionid: {}'.format(session_id))\n",
+    "\n",
+    "output_filename = os.expanduser('~/temp/newt_sessionid.txt')\n",
+    "with open(output_filename, 'w') as f:\n",
+    "    f.write(session_id)\n",
+    "    print('Wrote {}'.format(output_filename))\n",
+    "\n",
+    "# Sanity check -- get user's scratch directory\n",
+    "cookies = dict(newt_sessionid=session_id)\n",
+    "data = {\n",
+    "    'executable': 'echo $SCRATCH',\n",
+    "    'loginenv': 'true'\n",
+    "}\n",
+    "machine = 'cori'\n",
+    "url = '%s/command/%s' % (nersc_url, machine)\n",
+    "r = requests.post(url, data=data, cookies=cookies)\n",
+    "r.raise_for_status()\n",
+    "print(r.json())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/gaia/__init__.py
+++ b/gaia/__init__.py
@@ -205,6 +205,6 @@ def submit_crop(data_object, geometry_object, nersc_repository):
     # Hand off to cumulus interface
     from gaia.io.cumulus_interface import CumulusInterface
     cumulus_interface = CumulusInterface()
-    cumulus_interface.submit_crop(data_object, geometry_object, nersc_repository)
+    return cumulus_interface.submit_crop(data_object, geometry_object, nersc_repository)
 
 get_config()

--- a/gaia/__init__.py
+++ b/gaia/__init__.py
@@ -136,13 +136,6 @@ def get_config(config_file=None):
     config = config_dict
     return config_dict
 
-def get_datastore_url(path):
-    """Returns url (string) pointing to resource on remote datastore.
-
-    Returns None if the file is not found at the given path.
-    """
-
-
 
 def get_plugins():
     """
@@ -197,5 +190,22 @@ def save(data_object, filename, **options):
     :return boolean indicating success
     """
     return writers.write_gaia_object(data_object, filename, **options)
+
+def submit_crop(data_object, geomtry_object):
+    """Submits processing job to NERSC HPC machine
+
+    Current support is (only) for girder-hosted datasets
+
+    :param data_object: GirderDataObject to be cropped
+    :param geometry_object: GaiaDataObject specifying the crop geometry
+    :return job_id (string) that can be used for tracking and creating
+      new GaiaDataObject when job is complete.
+    """
+    from gaia.io.girder_interface import GirderInterface
+    girder_interface = GirderInterface.get_instance()
+    if not girder_interface.is_nersc_enabled:
+        raise GaiaProcessError('Girder was not connected with NEWT session id')
+
+    return 'no job id yet'
 
 get_config()

--- a/gaia/__init__.py
+++ b/gaia/__init__.py
@@ -48,7 +48,12 @@ sqlengines = {}
 config = {}
 
 
-def connect(girder_url='http://localhost:8989', username=None, password=None, apikey=None):
+def connect(
+    girder_url='http://localhost:8989',
+    username=None,
+    password=None,
+    apikey=None,
+    newt_sessionid=None):
     """Initialize a connection to a Girder data management system
 
     Gaia datasets can be created from girder files and folders using
@@ -63,7 +68,9 @@ def connect(girder_url='http://localhost:8989', username=None, password=None, ap
     'http://localhost:80' or 'https://my.girder.com'.
     :param username: (string) The name for logging into Girder.
     :param password: (string) The password for logging into Girder.
-    :apikey: (string)An api key, which can be used instead of username & password.
+    :apikey: (string) An api key, which can be used instead of username & password.
+    :newt_sessionid: (string) Session token from NEWT web service at NERSC.
+       (Girder must be connected to NEWT service to authenicate.)
 
     Note that applications can connect to only ONE girder instance for the
     entire session.
@@ -72,7 +79,8 @@ def connect(girder_url='http://localhost:8989', username=None, password=None, ap
     gint = GirderInterface.get_instance()
     if gint.is_initialized():
         raise GaiaException('GirderInterface already initialized.')
-    gint.initialize(girder_url, username=username, password=password, apikey=apikey)
+    gint.initialize(girder_url, username=username, password=password,
+        apikey=apikey, newt_sessionid=newt_sessionid)
     return gint
 
 def create(data_source, *args, **kwargs):

--- a/gaia/__init__.py
+++ b/gaia/__init__.py
@@ -191,7 +191,7 @@ def save(data_object, filename, **options):
     """
     return writers.write_gaia_object(data_object, filename, **options)
 
-def submit_crop(data_object, geomtry_object):
+def submit_crop(data_object, geometry_object):
     """Submits processing job to NERSC HPC machine
 
     Current support is (only) for girder-hosted datasets
@@ -201,11 +201,9 @@ def submit_crop(data_object, geomtry_object):
     :return job_id (string) that can be used for tracking and creating
       new GaiaDataObject when job is complete.
     """
-    from gaia.io.girder_interface import GirderInterface
-    girder_interface = GirderInterface.get_instance()
-    if not girder_interface.is_nersc_enabled:
-        raise GaiaProcessError('Girder was not connected with NEWT session id')
-
-    return 'no job id yet'
+    # Hand off to cumulus interface
+    from gaia.io.cumulus_interface import CumulusInterface
+    cumulus_interface = CumulusInterface()
+    cumulus_interface.submit_crop(data_object, geometry_object)
 
 get_config()

--- a/gaia/__init__.py
+++ b/gaia/__init__.py
@@ -191,19 +191,20 @@ def save(data_object, filename, **options):
     """
     return writers.write_gaia_object(data_object, filename, **options)
 
-def submit_crop(data_object, geometry_object):
+def submit_crop(data_object, geometry_object, nersc_repository):
     """Submits processing job to NERSC HPC machine
 
     Current support is (only) for girder-hosted datasets
 
     :param data_object: GirderDataObject to be cropped
     :param geometry_object: GaiaDataObject specifying the crop geometry
+    :param nersc_repository: (string) accounting repository (e.g., m1234)
     :return job_id (string) that can be used for tracking and creating
       new GaiaDataObject when job is complete.
     """
     # Hand off to cumulus interface
     from gaia.io.cumulus_interface import CumulusInterface
     cumulus_interface = CumulusInterface()
-    cumulus_interface.submit_crop(data_object, geometry_object)
+    cumulus_interface.submit_crop(data_object, geometry_object, nersc_repository)
 
 get_config()

--- a/gaia/display/pygeojs_adapter.py
+++ b/gaia/display/pygeojs_adapter.py
@@ -63,8 +63,9 @@ def show(data_objects, **options):
 
             # Convert to lon-lat if needed
             epsg = data_object.get_epsg()
-            if epsg != '4236':
-                df[df.geometry.name] = df.geometry.to_crs(epsg='4236')
+            if epsg and str(epsg) != '4326':
+                print('Converting crs')
+                df[df.geometry.name] = df.geometry.to_crs(epsg='4326')
 
             # Strip any z coordinates (force to z = 1)
             df.geometry = df.geometry.scale(zfact=0.0).translate(zoff=1.0)

--- a/gaia/display/pygeojs_adapter.py
+++ b/gaia/display/pygeojs_adapter.py
@@ -97,8 +97,8 @@ def show(data_objects, **options):
 
             # meta bounds inconsistent between sources, so compute brute force
             xvals, yvals = zip(*raster_bounds)
-            xmin = min(xvals); ymin = min(yvals)
-            xmax = max(xvals); ymax = max(yvals)
+            xmin, xmax = min(xvals), max(xvals)
+            ymin, ymax = min(yvals), max(yvals)
             meta_bounds = [
                 [xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]
             ]

--- a/gaia/display/pygeojs_adapter.py
+++ b/gaia/display/pygeojs_adapter.py
@@ -91,9 +91,17 @@ def show(data_objects, **options):
             meta = data_object.get_metadata()
             # print('meta: {}'.format(meta))
             # print(meta)
-            meta_bounds = meta.get('bounds').get('coordinates')[0]
+            raster_bounds = meta.get('bounds').get('coordinates')[0]
             # print(meta_bounds)
-            assert meta_bounds, 'data_object missing bounds'
+            assert raster_bounds, 'data_object missing bounds'
+
+            # meta bounds inconsistent between sources, so compute brute force
+            xvals, yvals = zip(*raster_bounds)
+            xmin = min(xvals); ymin = min(yvals)
+            xmax = max(xvals); ymax = max(yvals)
+            meta_bounds = [
+                [xmin, ymin], [xmax, ymin], [xmax, ymax], [xmin, ymax]
+            ]
 
         # Bounds format is [xmin, ymin, xmax, ymax]
         bounds = [
@@ -146,7 +154,9 @@ def show(data_objects, **options):
                 # Todo - verify that it is installed
                 tiles_url = data_object._get_tiles_url()
                 # print('tiles_url', tiles_url)
-                opacity = data_object.opacity
+                opacity = 1.0
+                if hasattr(data_object, 'opacity'):
+                    opacity = data_object.opacity
                 scene.createLayer(
                     'osm', url=tiles_url, keepLower=False, opacity=opacity)
             else:

--- a/gaia/io/cumulus_interface.py
+++ b/gaia/io/cumulus_interface.py
@@ -1,0 +1,371 @@
+# =============================================================================
+#
+#  Copyright (c) Kitware, Inc.
+#  All rights reserved.
+#  See LICENSE.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even
+#  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+#  PURPOSE.  See the above copyright notice for more information.
+#
+# =============================================================================
+from girder_client import GirderClient, HttpError
+import girder_client
+import requests
+import uuid
+import time
+import sys
+import os
+import json
+print 'Loading cumulusclient'
+
+
+class CumulusClient():
+    '''Application interface to cumulus-based client for HPC systems
+    supporting NEWT API.
+
+    Note: the methods must be called in a specific order!
+      create_cluster()
+      create_slurm_script()
+      create_job()
+      upload_inputs()
+      submit_job()
+
+    Then optionally:
+      monitor_job()
+      download_results()
+      release_resources()
+    '''
+    # ---------------------------------------------------------------------
+
+    def __init__(self, girder_url, newt_sessionid):
+        '''
+        '''
+        self._client = None
+        self._cluster_id = None
+        self._girder_url = girder_url
+        self._input_folder_id = None
+        self._job_folder_id = None
+        self._job_id = None
+        self._output_folder_id = None
+        self._private_folder_id = None
+        self._script_id = None
+        self._session = requests.Session()
+
+        # Authenticate with Girder using the newt session id
+        url = '%s/api/v1/newt/authenticate/%s' % \
+            (self._girder_url, newt_sessionid)
+        r = self._session.put(url)
+        if r.status_code != 200:
+            raise HttpError(r.status_code, r.text, r.url, r.request.method)
+
+        # Instantiate Girder client
+        url = '%s/api/v1' % self._girder_url
+        self._client = GirderClient(apiUrl=url)
+        self._client.token = self._session.cookies['girderToken']
+
+        user = self._client.get('user/me')
+        # print 'user', user
+        user_id = user['_id']
+        r = self._client.listFolder(user_id, 'user', name='Private')
+        # Getting mixed signals on what listFolder returns
+        # I *think* it is a generator
+        try:
+            self._private_folder_id = r.next()['_id']
+        except Exception as ex:
+            # But just in case
+            self._private_folder_id = r[0]['_id']
+        print 'private_folder_id', self._private_folder_id
+
+    # ---------------------------------------------------------------------
+    def job_id(self):
+        '''Returns current job id (which may be None)
+        '''
+        return self._job_id
+
+    # ---------------------------------------------------------------------
+    def create_cluster(self, machine_name, cluster_name=None):
+        '''
+        '''
+        if cluster_name is None:
+            user = self._client.get('user/me')
+            user_name = user.get('firstName', 'user')
+            cluster_name = '%s.%s' % (machine_name, user_name)
+
+        cluster = None
+        cluster_list = self._client.get('clusters')
+        for extant_cluster in cluster_list:
+            if extant_cluster['name'] == cluster_name:
+                cluster = extant_cluster
+                self._cluster_id = extant_cluster['_id']
+                break
+
+        if not cluster:
+            body = {
+                'config': {
+                    'host': machine_name
+                },
+                'name': cluster_name,
+                'type': 'newt'
+            }
+
+            r = self._client.post('clusters', data=json.dumps(body))
+            self._cluster_id = r['_id']
+            print 'cluster_id', self._cluster_id
+
+        # Reset the state of the cluster
+        body = {
+            'status': 'created'
+        }
+        r = self._client.patch('clusters/%s' %
+                               self._cluster_id, data=json.dumps(body))
+
+        # Now test the connection
+        r = self._client.put('clusters/%s/start' % self._cluster_id)
+        sleeps = 0
+        while True:
+            time.sleep(1)
+            r = self._client.get('clusters/%s/status' % self._cluster_id)
+
+            if r['status'] == 'running':
+                break
+            elif r['status'] == 'error':
+                r = self._client.get('clusters/%s/log' % self._cluster_id)
+                print r
+                raise Exception('ERROR creating cluster')
+
+            if sleeps > 9:
+                raise Exception('Cluster never moved into running state')
+            sleeps += 1
+
+    # ---------------------------------------------------------------------
+    def create_slurm_script(self, name, command_list):
+        '''Creates script to submit job
+        '''
+        body = {
+            'commands': command_list,
+            'name': name
+        }
+        r = self._client.post('scripts', data=json.dumps(body))
+        self._script_id = r['_id']
+        print 'script_id', self._script_id
+
+    # ---------------------------------------------------------------------
+    def create_job(self, job_name, tail=None):
+        '''
+        '''
+        # Create job folders
+        folder_name = uuid.uuid4().hex  # unique name
+        self._job_folder_id = self.get_folder(
+            self._private_folder_id, folder_name)
+        print 'Created job folder', folder_name
+        self._input_folder_id = self.get_folder(
+            self._job_folder_id, 'input_files')
+        self._output_folder_id = self.get_folder(
+            self._job_folder_id, 'output_files')
+        # Make sure job_name isn't null
+        if not job_name:
+            job_name = 'CumulusJob'
+
+        # Create job spec
+        body = {
+            'name': job_name,
+            'scriptId': self._script_id,
+            'output': [{
+                'folderId': self._output_folder_id,
+                'path': '.'
+            }],
+            'input': [
+                {
+                    'folderId': self._input_folder_id,
+                    'path': '.'
+                }
+            ]
+        }
+
+        if tail:
+            body['output'].append({
+                "path": tail,
+                "tail": True
+            })
+
+        job = self._client.post('jobs', data=json.dumps(body))
+        self._job_id = job['_id']
+        print 'Created job_id', self._job_id
+
+    # ---------------------------------------------------------------------
+    def upload_inputs(self, files_to_upload, folders_to_upload=[]):
+        '''Uploads input files to (girder) input folder
+        '''
+        if not self._input_folder_id:
+            raise Exception('Input folder missing')
+
+        def upload_file(path):
+            name = os.path.basename(path)
+            size = os.path.getsize(path)
+            with open(path, 'rb') as fp:
+                self._client.uploadFile(
+                    self._input_folder_id, fp, name, size, parentType='folder')
+
+        for file_path in files_to_upload:
+            if not file_path or not os.path.exists(file_path):
+                raise Exception('Input file not found: %s' % file_path)
+            upload_file(file_path)
+
+        for folder_path in folders_to_upload:
+            if not folder_path or not os.path.exists(folder_path):
+                raise Exception('Input folder not found: %s' % folder_path)
+            # Create folder on girder
+            basename = os.path.basename(folder_path)
+            new_folder = self._client.createFolder(
+                self._input_folder_id, basename)
+            # Upload files
+            pattern = '%s/*' % folder_path
+            self._client.upload(pattern, new_folder._id)
+
+    # ---------------------------------------------------------------------
+    def submit_job(self,
+                   machine,
+                   project_account,
+                   job_output_dir,
+                   timeout_minutes,
+                   queue='debug',
+                   qos=None,
+                   number_of_nodes=1):
+        '''
+        '''
+        body = {
+            'machine': machine,
+            'account': project_account,
+            'numberOfNodes': number_of_nodes,
+            'maxWallTime': {
+                'hours': 0,
+                'minutes': timeout_minutes,
+                'seconds': 0
+            },
+            'queue': queue,
+        }
+        if 'cori' == machine:
+            body['constraint'] = 'haswell'
+
+        if qos:
+            body['qualityOfService'] = qos
+
+        body['jobOutputDir'] = job_output_dir
+
+        print 'submit_job body:', body
+        url = 'clusters/%s/job/%s/submit' % (self._cluster_id, self._job_id)
+        self._client.put(url, data=json.dumps(body))
+        print 'Submitted job', self._job_id
+
+    # ---------------------------------------------------------------------
+    def set_job_metadata(self, meta):
+        '''Writes metadata to job
+        '''
+        body = dict()
+        body['metadata'] = meta
+        r = self._client.patch('jobs/%s' % self._job_id, data=json.dumps(body))
+
+    # ---------------------------------------------------------------------
+    def monitor_job(self, tail=None):
+        '''Periodically monitors job status
+        '''
+        log_offset = 0
+        job_timeout = 60 * timeout_minutes
+        start = time.time()
+        while True:
+            time.sleep(2)
+
+            # Provide some feedback at startup
+            if log_offset == 0:
+                sys.stdout.write('.')
+
+            # print 'Checking status'
+            r = self._client.get('jobs/%s' % self._job_id)
+            # print r
+
+            if r['status'] in ['error', 'unexpectederror']:
+                r = self._client.get('jobs/%s/log' % self._job_id)
+                raise Exception(str(r))
+            elif r['status'] == 'complete':
+                break
+
+            # Tail log file
+            if tail:
+                params = {
+                    'offset': log_offset,
+                    'path': tail
+                }
+                # print 'Checking tail'
+                r = self._client.get('jobs/%s/output' %
+                                     self._job_id, parameters=params)
+                # print r
+                output = r['content']
+
+                if output and log_offset == 0:
+                    print  # end the user feedback dots
+
+                log_offset += len(output)
+
+                for l in output:
+                    print l
+
+            sys.stdout.flush()
+
+            if time.time() - start > job_timeout:
+                raise Exception('Job timeout')
+
+    # ---------------------------------------------------------------------
+    def download_results(self, destination_folder):
+        '''Downloads all output files to a local directory
+
+        '''
+        if not os.path.exists(destination_folder):
+            os.makedirs(destination_folder)
+
+        self._client.downloadFolderRecursive(
+            self._output_folder_id, destination_folder)
+
+        print 'Downloaded files to %s' % destination_folder
+
+    # ---------------------------------------------------------------------
+    def release_resources(self):
+        '''Closes/deletes any current resources
+
+        '''
+        resource_info = {
+            'clusters': [self._cluster_id],
+            'jobs': [self._job_id],
+            'scripts': [self._script_id],
+            'folder': [self._job_folder]
+        }
+        for resource_type, id_list in resource_info.items():
+            for resource_id in id_list:
+                if resource_id is not None:
+                    url = '%s/%s' % (resource_type, resource_id)
+                    self._client.delete(url)
+
+        self._input_folder_id = None
+        self._job_folder_id = None
+        self._job_id = None
+        self._output_folder_id = None
+        self._script_id = None
+
+    # ---------------------------------------------------------------------
+    def get_folder(self, parent_id, name):
+        '''Returns folder_id, creating one if needed
+        '''
+        # Check if folder already exists
+        folder_list = list(self._client.listFolder(parent_id, name=name))
+        if folder_list:
+            folder = folder_list[0]
+            return folder['_id']
+
+        # (else)
+        try:
+            r = self._client.createFolder(parent_id, name)
+            return r['_id']
+        except HttpError as e:
+            print e.responseText
+
+        return None

--- a/gaia/io/cumulus_interface.py
+++ b/gaia/io/cumulus_interface.py
@@ -17,83 +17,78 @@ import time
 import sys
 import os
 import json
-print 'Loading cumulusclient'
+
+from gaia.io.girder_interface import GirderInterface
+from gaia.util import GaiaException
 
 
-class CumulusClient():
-    '''Application interface to cumulus-based client for HPC systems
-    supporting NEWT API.
+class CumulusInterface():
+    """An internal class that submits jobs to NERSC via girder/cumulus
 
-    Note: the methods must be called in a specific order!
-      create_cluster()
-      create_slurm_script()
-      create_job()
-      upload_inputs()
-      submit_job()
+    This class uses the girder client owned by GirderInterface, which must be
+    authenticated with NERSC (NEWT api).
+    """
 
-    Then optionally:
-      monitor_job()
-      download_results()
-      release_resources()
-    '''
     # ---------------------------------------------------------------------
+    def __init__(self):
+        """Recommend using separate instance for each job submission.
+        """
+        self._girder_client = None
+        self._private_folder_id = None
 
-    def __init__(self, girder_url, newt_sessionid):
-        '''
-        '''
-        self._client = None
+        # Internal, job-specific ids
         self._cluster_id = None
-        self._girder_url = girder_url
         self._input_folder_id = None
         self._job_folder_id = None
         self._job_id = None
         self._output_folder_id = None
-        self._private_folder_id = None
         self._script_id = None
-        self._session = requests.Session()
 
-        # Authenticate with Girder using the newt session id
-        url = '%s/api/v1/newt/authenticate/%s' % \
-            (self._girder_url, newt_sessionid)
-        r = self._session.put(url)
-        if r.status_code != 200:
-            raise HttpError(r.status_code, r.text, r.url, r.request.method)
+        girder_interface = GirderInterface.get_instance()
+        if not girder_interface.is_nersc_enabled:
+            msg = """GirderInterface is not configured for NERSC job submission -- \
+must authenticate with NEWT session id."""
+            raise GaiaException(msg)
 
-        # Instantiate Girder client
-        url = '%s/api/v1' % self._girder_url
-        self._client = GirderClient(apiUrl=url)
-        self._client.token = self._session.cookies['girderToken']
+        # Get Girder client
+        self._girder_client = girder_interface.gc
 
-        user = self._client.get('user/me')
-        # print 'user', user
+        # Get id for user's private folder
+        user = self._girder_client.get('user/me')
+        print('user', user)
         user_id = user['_id']
-        r = self._client.listFolder(user_id, 'user', name='Private')
+        r = self._girder_client.listFolder(user_id, 'user', name='Private')
         # Getting mixed signals on what listFolder returns
         # I *think* it is a generator
         try:
-            self._private_folder_id = r.next()['_id']
+            self._private_folder_id = next(r)['_id']
         except Exception as ex:
             # But just in case
             self._private_folder_id = r[0]['_id']
-        print 'private_folder_id', self._private_folder_id
+        print('private_folder_id', self._private_folder_id)
 
     # ---------------------------------------------------------------------
-    def job_id(self):
-        '''Returns current job id (which may be None)
-        '''
-        return self._job_id
+    def submit_crop(self, input_object, crop_object):
+        pass
+        # Note: the methods must be called in a specific order!
+        #   create_cluster()
+        #   create_slurm_script()
+        #   create_job()
+        #   upload_inputs()
+        #   submit_job()
+        #   ? download_results()
 
     # ---------------------------------------------------------------------
     def create_cluster(self, machine_name, cluster_name=None):
         '''
         '''
         if cluster_name is None:
-            user = self._client.get('user/me')
+            user = self._girder_client.get('user/me')
             user_name = user.get('firstName', 'user')
             cluster_name = '%s.%s' % (machine_name, user_name)
 
         cluster = None
-        cluster_list = self._client.get('clusters')
+        cluster_list = self._girder_client.get('clusters')
         for extant_cluster in cluster_list:
             if extant_cluster['name'] == cluster_name:
                 cluster = extant_cluster
@@ -109,29 +104,29 @@ class CumulusClient():
                 'type': 'newt'
             }
 
-            r = self._client.post('clusters', data=json.dumps(body))
+            r = self._girder_client.post('clusters', data=json.dumps(body))
             self._cluster_id = r['_id']
-            print 'cluster_id', self._cluster_id
+            print('cluster_id', self._cluster_id)
 
         # Reset the state of the cluster
         body = {
             'status': 'created'
         }
-        r = self._client.patch('clusters/%s' %
+        r = self._girder_client.patch('clusters/%s' %
                                self._cluster_id, data=json.dumps(body))
 
         # Now test the connection
-        r = self._client.put('clusters/%s/start' % self._cluster_id)
+        r = self._girder_client.put('clusters/%s/start' % self._cluster_id)
         sleeps = 0
         while True:
             time.sleep(1)
-            r = self._client.get('clusters/%s/status' % self._cluster_id)
+            r = self._girder_client.get('clusters/%s/status' % self._cluster_id)
 
             if r['status'] == 'running':
                 break
             elif r['status'] == 'error':
-                r = self._client.get('clusters/%s/log' % self._cluster_id)
-                print r
+                r = self._girder_client.get('clusters/%s/log' % self._cluster_id)
+                print(r)
                 raise Exception('ERROR creating cluster')
 
             if sleeps > 9:
@@ -146,9 +141,9 @@ class CumulusClient():
             'commands': command_list,
             'name': name
         }
-        r = self._client.post('scripts', data=json.dumps(body))
+        r = self._girder_client.post('scripts', data=json.dumps(body))
         self._script_id = r['_id']
-        print 'script_id', self._script_id
+        print('script_id', self._script_id)
 
     # ---------------------------------------------------------------------
     def create_job(self, job_name, tail=None):
@@ -158,7 +153,7 @@ class CumulusClient():
         folder_name = uuid.uuid4().hex  # unique name
         self._job_folder_id = self.get_folder(
             self._private_folder_id, folder_name)
-        print 'Created job folder', folder_name
+        print('Created job folder', folder_name)
         self._input_folder_id = self.get_folder(
             self._job_folder_id, 'input_files')
         self._output_folder_id = self.get_folder(
@@ -189,9 +184,9 @@ class CumulusClient():
                 "tail": True
             })
 
-        job = self._client.post('jobs', data=json.dumps(body))
+        job = self._girder_client.post('jobs', data=json.dumps(body))
         self._job_id = job['_id']
-        print 'Created job_id', self._job_id
+        print('Created job_id', self._job_id)
 
     # ---------------------------------------------------------------------
     def upload_inputs(self, files_to_upload, folders_to_upload=[]):
@@ -204,7 +199,7 @@ class CumulusClient():
             name = os.path.basename(path)
             size = os.path.getsize(path)
             with open(path, 'rb') as fp:
-                self._client.uploadFile(
+                self._girder_client.uploadFile(
                     self._input_folder_id, fp, name, size, parentType='folder')
 
         for file_path in files_to_upload:
@@ -217,11 +212,11 @@ class CumulusClient():
                 raise Exception('Input folder not found: %s' % folder_path)
             # Create folder on girder
             basename = os.path.basename(folder_path)
-            new_folder = self._client.createFolder(
+            new_folder = self._girder_client.createFolder(
                 self._input_folder_id, basename)
             # Upload files
             pattern = '%s/*' % folder_path
-            self._client.upload(pattern, new_folder._id)
+            self._girder_client.upload(pattern, new_folder._id)
 
     # ---------------------------------------------------------------------
     def submit_job(self,
@@ -253,10 +248,10 @@ class CumulusClient():
 
         body['jobOutputDir'] = job_output_dir
 
-        print 'submit_job body:', body
+        print('submit_job body:', body)
         url = 'clusters/%s/job/%s/submit' % (self._cluster_id, self._job_id)
-        self._client.put(url, data=json.dumps(body))
-        print 'Submitted job', self._job_id
+        self._girder_client.put(url, data=json.dumps(body))
+        print('Submitted job', self._job_id)
 
     # ---------------------------------------------------------------------
     def set_job_metadata(self, meta):
@@ -264,56 +259,7 @@ class CumulusClient():
         '''
         body = dict()
         body['metadata'] = meta
-        r = self._client.patch('jobs/%s' % self._job_id, data=json.dumps(body))
-
-    # ---------------------------------------------------------------------
-    def monitor_job(self, tail=None):
-        '''Periodically monitors job status
-        '''
-        log_offset = 0
-        job_timeout = 60 * timeout_minutes
-        start = time.time()
-        while True:
-            time.sleep(2)
-
-            # Provide some feedback at startup
-            if log_offset == 0:
-                sys.stdout.write('.')
-
-            # print 'Checking status'
-            r = self._client.get('jobs/%s' % self._job_id)
-            # print r
-
-            if r['status'] in ['error', 'unexpectederror']:
-                r = self._client.get('jobs/%s/log' % self._job_id)
-                raise Exception(str(r))
-            elif r['status'] == 'complete':
-                break
-
-            # Tail log file
-            if tail:
-                params = {
-                    'offset': log_offset,
-                    'path': tail
-                }
-                # print 'Checking tail'
-                r = self._client.get('jobs/%s/output' %
-                                     self._job_id, parameters=params)
-                # print r
-                output = r['content']
-
-                if output and log_offset == 0:
-                    print  # end the user feedback dots
-
-                log_offset += len(output)
-
-                for l in output:
-                    print l
-
-            sys.stdout.flush()
-
-            if time.time() - start > job_timeout:
-                raise Exception('Job timeout')
+        r = self._girder_client.patch('jobs/%s' % self._job_id, data=json.dumps(body))
 
     # ---------------------------------------------------------------------
     def download_results(self, destination_folder):
@@ -323,10 +269,10 @@ class CumulusClient():
         if not os.path.exists(destination_folder):
             os.makedirs(destination_folder)
 
-        self._client.downloadFolderRecursive(
+        self._girder_client.downloadFolderRecursive(
             self._output_folder_id, destination_folder)
 
-        print 'Downloaded files to %s' % destination_folder
+        print('Downloaded files to %s' % destination_folder)
 
     # ---------------------------------------------------------------------
     def release_resources(self):
@@ -343,7 +289,7 @@ class CumulusClient():
             for resource_id in id_list:
                 if resource_id is not None:
                     url = '%s/%s' % (resource_type, resource_id)
-                    self._client.delete(url)
+                    self._girder_client.delete(url)
 
         self._input_folder_id = None
         self._job_folder_id = None
@@ -356,16 +302,16 @@ class CumulusClient():
         '''Returns folder_id, creating one if needed
         '''
         # Check if folder already exists
-        folder_list = list(self._client.listFolder(parent_id, name=name))
+        folder_list = list(self._girder_client.listFolder(parent_id, name=name))
         if folder_list:
             folder = folder_list[0]
             return folder['_id']
 
         # (else)
         try:
-            r = self._client.createFolder(parent_id, name)
+            r = self._girder_client.createFolder(parent_id, name)
             return r['_id']
         except HttpError as e:
-            print e.responseText
+            print(e.responseText)
 
         return None

--- a/gaia/io/girder_interface.py
+++ b/gaia/io/girder_interface.py
@@ -10,7 +10,7 @@ from gaia.util import GaiaException, MissingParameterError
 class GirderInterface(object):
     """An internal class that provides a thin encapsulation of girder_client.
 
-    This class must be sued as a singleton.
+    This class must be used as a singleton.
     """
 
     instance = None  # singleton

--- a/gaia/io/girder_interface.py
+++ b/gaia/io/girder_interface.py
@@ -51,7 +51,8 @@ class GirderInterface(object):
         # (else)
         return True
 
-    def initialize(self,
+    def initialize(
+            self,
             girder_url,
             username=None,
             password=None,
@@ -88,7 +89,8 @@ class GirderInterface(object):
             url = '{}/newt/authenticate/{}'.format(api_url, newt_sessionid)
             r = self.nersc_requests.put(url)
             r.raise_for_status()
-            self.nersc_requests.cookies.update(dict(newt_sessionid=newt_sessionid))
+            self.nersc_requests.cookies.update(dict(
+                newt_sessionid=newt_sessionid))
 
             self.gc.token = self.nersc_requests.cookies['girderToken']
         else:
@@ -127,7 +129,6 @@ class GirderInterface(object):
                 self.gaia_folder['_id'], 'default', description=description)
             print('Created gaia/default folder')
 
-
     def lookup_url(self, path=None, job_id=None, test=False):
         """Returns internal url for resource at specified path
 
@@ -157,31 +158,37 @@ class GirderInterface(object):
             status = job_info.get('status')
             if status != 'complete':
                 print('job_info:\n', job_info)
-                raise GaiaException('Job status not complete ({})'.format(status))
+                raise GaiaException(
+                    'Job status not complete ({})'.format(status))
 
-            output_folder_id = job_info.get('output',[])[0].get('folderId')
+            output_folder_id = job_info.get('output', [])[0].get('folderId')
             # print('output_folder_id', output_folder_id)
 
             # Output filename is stored in metadata
             default_filename = 'output.tif'
-            output_filename = job_info.get('metadata',{}).get('outputFilename',default_filename)
+            metadata = job_info.get('metadata', {})
+            output_filename = metadata.get('outputFilename', default_filename)
 
             # Get item id
-            params = dict(folderId=output_folder_id, name=output_filename, limit=1)
+            params = dict(
+                folderId=output_folder_id, name=output_filename, limit=1)
             output_list = self.gc.get('item', parameters=params)
-            #print(output_list)
+            # print(output_list)
             if output_list:
                 output_info = output_list[0]
                 output_item_id = output_info.get('_id', 'missing')
-                # print('Output file {} is item id {}'.format(output_filename, output_item_id))
+                # print('Output file {} is item id {}'.format(
+                #     output_filename, output_item_id))
             else:
-                raise GaiaException('Output file {} not found'.format(output_filename))
+                raise GaiaException(
+                    'Output file {} not found'.format(output_filename))
 
             # Create gaia object for output
             gaia_url = 'girder://item/{}'.format(output_item_id)
             return gaia_url
         else:
-            raise MissingParameterError('Must specify either path or job_id argument')
+            raise MissingParameterError(
+                'Must specify either path or job_id argument')
 
     def lookup_resource(self, path, test=True):
         """Does lookup of resource at specified path

--- a/gaia/io/girder_interface.py
+++ b/gaia/io/girder_interface.py
@@ -29,8 +29,7 @@ class GirderInterface(object):
         self.user = None  # girder user object
         self.gaia_folder = None
         self.default_folder = None
-        self.requests_session = None  # use for NERSC interface
-        self.is_nersc_enabled = False # ditto
+        self.nersc_requests = None  # requests session
 
     @classmethod
     def get_instance(cls):
@@ -85,13 +84,13 @@ class GirderInterface(object):
         elif apikey is not None:
             self.gc.authenticate(apiKey=apikey)
         elif newt_sessionid is not None:
-            self.requests_session = requests.Session()
+            self.nersc_requests = requests.Session()
             url = '{}/newt/authenticate/{}'.format(api_url, newt_sessionid)
-            r = self.requests_session.put(url)
+            r = self.nersc_requests.put(url)
             r.raise_for_status()
+            self.nersc_requests.cookies.update(dict(newt_sessionid=newt_sessionid))
 
-            self.gc.token = self.requests_session.cookies['girderToken']
-            self.is_nersc_enabled = True
+            self.gc.token = self.nersc_requests.cookies['girderToken']
         else:
             raise MissingParameterError('No girder credentials provided.')
 

--- a/gaia/io/girder_reader.py
+++ b/gaia/io/girder_reader.py
@@ -41,7 +41,7 @@ class GirderReader(GaiaReader):
             # (else)
             return False
         else:
-            if not isinstance(source, tuple) and not len(source) == 2:
+            if not isinstance(source, tuple) or not len(source) == 2:
                 return False
 
             gint, path = source

--- a/gaia/io/girder_reader.py
+++ b/gaia/io/girder_reader.py
@@ -19,6 +19,8 @@ class GirderReader(GaiaReader):
         super(GirderReader, self).__init__(*args, **kwargs)
         self.girder_source = data_source
         self.url = None
+        # Bounds can be pass in optionally
+        self.bounds = kwargs.get('bounds')
 
         if isinstance(data_source, str):
             self.url = data_source
@@ -74,7 +76,8 @@ class GirderReader(GaiaReader):
                 raise GaiaException('Internal error - not a girder url')
 
             resource_type, resource_id = parsed_result
-            return GirderDataObject(self, resource_type, resource_id)
+            return GirderDataObject(
+                self, resource_type, resource_id, bounds=self.bounds)
 
         elif self.girder_source:
             gint, path = self.girder_source
@@ -86,7 +89,8 @@ class GirderReader(GaiaReader):
 
             resource_type = resource['_modelType']
             resource_id = resource['_id']
-            return GirderDataObject(self, resource_type, resource_id)
+            return GirderDataObject(
+                self, resource_type, resource_id, bounds=self.bounds)
 
         raise GaiaException(
             'Internal error - should never reach end of GirderReader.read()')

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -5,4 +5,4 @@ show-source: True
 max-complexity: 30
 format: pylint
 ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,E402,F401,N802,N803,N806,N812
-exclude: __init__.py, docs, deprecated_*.py
+exclude: __init__.py, docs, deprecated_*.py, geolib.py


### PR DESCRIPTION
Adds new capability to submit jobs on NERSC (Cori machine) to crop raster datasets.

* Extends gaia.connect() to accept NEWT session id for authentication
* Adds gaia.submit_crop() to submit jobs to Cori
* Adds nersc_login,ipynb and job_submit.ipynb notebooks to docs/examples folder
* Adds geolib.py file to provide "geolib" alias
* Updates GirderInterface.lookup_url() to accept cumulus job id as input
* Adds GirderInterface.ls() to list files in girder folder
* Updates gaia.create() to accept optional bounds argument (needed for data from ESS-DIVE and cumulus asset stores)
