### PR TITLE
Update crop functions to handle partial and null intersection cases

### DIFF
--- a/gaia/geo/gdal_functions.py
+++ b/gaia/geo/gdal_functions.py
@@ -261,9 +261,24 @@ def gdal_clip(raster_input, raster_output, polygon_json, nodata=0):
     ul_x, ul_y = world_to_pixel(geo_trans, min_x, max_y)
     lr_x, lr_y = world_to_pixel(geo_trans, max_x, min_y)
 
+    # Check for null intersection
+    if lr_x < 0 or lr_y < 0 \
+            or ul_x > src_array.shape[-1] \
+            or ul_y > src_array.shape[-2]:
+        return None
+
+    # Clip to the input image bounds
+    ul_x = max(ul_x, 0)
+    ul_y = max(ul_y, 0)
+    lr_x = min(lr_x, src_array.shape[-1])
+    lr_y = min(lr_y, src_array.shape[-2])
+
     # Calculate the pixel size of the new image
     px_width = int(lr_x - ul_x)
     px_height = int(lr_y - ul_y)
+
+    if px_width < 1 or px_height < 1:
+        return None
 
     if raster_input.RasterCount == 1:
         clip = src_array[ul_y:lr_y, ul_x:lr_x]

--- a/gaia/preprocess/__init__.py
+++ b/gaia/preprocess/__init__.py
@@ -13,6 +13,7 @@ def crop (*args, **kwargs):
     :param datasets: list of datasets to crop
     :param geometry: crop geometry in GeoJSON format
     :param name: optional name for resulting dataset
+    :return: dataset or None if no intersection
     """
     return compute('crop', inputs=list(args), args=kwargs)
 

--- a/gaia/preprocess/gdal_processes.py
+++ b/gaia/preprocess/gdal_processes.py
@@ -41,6 +41,8 @@ def compute_subset_gdal(inputs=[], args=[]):
     # Passing "None" as second arg instead of a file path.  This tells gdal_clip
     # not to write the output dataset to a tiff file on disk
     output_dataset = gdal_clip(raster_img, None, clip_json)
+    if output_dataset is None:
+        return None
 
     # Copy data to new GDALDataObject
     outputDataObject = GDALDataObject()

--- a/gaia/preprocess/pandas_processes.py
+++ b/gaia/preprocess/pandas_processes.py
@@ -39,7 +39,8 @@ def crop_pandas(inputs=[], args={}):
     """
     Calculate the within process using pandas GeoDataFrames
 
-    :return: within result as a GeoDataFrame
+    :return: within result as a GaiaDataObject,
+             or None if no intersection
     """
     first, second = inputs[0], inputs[1]
     if first.get_epsg() != second.get_epsg():
@@ -47,6 +48,9 @@ def crop_pandas(inputs=[], args={}):
     first_df, second_df = first.get_data(), second.get_data()
     first_within = first_df[first_df.geometry.within(
         second_df.geometry.unary_union)]
+
+    if first_within.empty:
+        return None
 
     # Construct GaiaDataObject manually
     # Todo consider adding static method to GaiaDataObject

--- a/geolib.py
+++ b/geolib.py
@@ -1,2 +1,3 @@
-# This provides an alias to "gaia", so that people can start using geolib
+# This provides an alias to "gaia", so that people can start using "geolib"
 from gaia import *
+import gaia.preprocess as preprocess


### PR DESCRIPTION
Adds some intersection checks and constrains the raster clipping "mask" to the input extents.

The logic returns None for the case of a null intersection, so the application should check the return value from crop(). In the future, we should consider adding a flag to indicate that a GaiaDataObject is empty, or possibly add an "empty" subclass of GaiaDataObject.